### PR TITLE
Fix encoding issue (non UTF-8 characters) and maven build after API level change

### DIFF
--- a/ComicReader/src/com/blogspot/applications4android/comicreader/comics/MenageA3.java
+++ b/ComicReader/src/com/blogspot/applications4android/comicreader/comics/MenageA3.java
@@ -156,7 +156,7 @@ public class MenageA3 extends ArchivedComic {
 		final_str = final_str.replaceAll("\".*", "");
 		final_title = final_title.replaceAll(".*.::", "");
 		final_title = final_title.replaceAll("</title>.*", "");
-		strip.setTitle("Ménage à 3 :" + final_title);
+		strip.setTitle("MÃ©nage Ã  3 :" + final_title);
 		return final_str;
 	}
 

--- a/ComicReaderTest/project.properties
+++ b/ComicReaderTest/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-7
+target=android-8

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</modules>
 	<properties>
 		<platform.version>2.1.2</platform.version>
-		<sdk.platform>7</sdk.platform>
+		<sdk.platform>8</sdk.platform>
 		<java.version>1.6</java.version>
 		<maven.test.skip>true</maven.test.skip>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The maven build errored out with:

[ERROR] ComicReader/ComicReader/src/com/blogspot/applications4android/comicreader/comics/MenageA3.java:[159,19] error: unmappable character for encoding UTF-8
[ERROR] ComicReader/ComicReader/src/com/blogspot/applications4android/comicreader/comics/MenageA3.java:[159,25] error: unmappable character for encoding UTF-8

Because of invalid characters.  I got the correct characters from this website:
http://www.fileformat.info/info/charset/UTF-8/list.htm

Also the api level needed changed to 8 from 7 because of the installLocation addition in the manifest.
